### PR TITLE
Add cmake-generated files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,11 +30,22 @@
 *.exe
 *.out
 *.app
+bin/
 
 # Clion files
 *.idea/*
 *cmake-build-debug/*
 *build/*
 
-# Qt files
-*CMakeLists.txt.user
+# Cmake generated files
+**/cmake-build-debug
+**/CMakeCache.txt
+**/cmake_install.cmake
+**/install_manifest.txt
+**/CMakeFiles/
+**/CTestTestfile.cmake
+**/Makefile
+**/*.cbp
+**/CMakeScripts
+**/compile_commands.json
+googletest-prefix/

--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,10 @@ bin/
 *cmake-build-debug/*
 *build/*
 
-# Cmake generated files
+# Googletest
+googletest-prefix/
+
+# Cmake files
 **/cmake-build-debug
 **/CMakeCache.txt
 **/cmake_install.cmake
@@ -48,4 +51,3 @@ bin/
 **/*.cbp
 **/CMakeScripts
 **/compile_commands.json
-googletest-prefix/


### PR DESCRIPTION
I think the files generated by build tool should be in .gitignore