### PR TITLE
Fix include error in Game.cpp

### DIFF
--- a/Map/Source/Game.cpp
+++ b/Map/Source/Game.cpp
@@ -1,4 +1,5 @@
 #include "Game.hpp"
+#include <cctype>
 
 Direction Game::getDirection()
 {


### PR DESCRIPTION
make error:
```
/home/gizlu/Dev/BakcylProgramowania_2019/Map/Source/Game.cpp: In member function ‘Direction Game::getDirection()’:                             
/home/gizlu/Dev/BakcylProgramowania_2019/Map/Source/Game.cpp:8:17: error: ‘tolower’ is not a member of ‘std’                                   
    8 |     switch(std::tolower(direction))                                                                                                    
      |                 ^~~~~~~                                                                                                                
/home/gizlu/Dev/BakcylProgramowania_2019/Map/Source/Game.cpp:25:1: error: control reaches end of non-void function [-Werror=return-type]       
   25 | }                                                                                                                                      
      | ^                                                                                                                                      
cc1plus: all warnings being treated as errors                                                                                                  
make[2]: *** [CMakeFiles/source_objects_lib.dir/build.make:135: CMakeFiles/source_objects_lib.dir/Map/Source/Game.cpp.o] Error 1               
make[1]: *** [CMakeFiles/Makefile2:324: CMakeFiles/source_objects_lib.dir/all] Error 2                                                         
make: *** [Makefile:104: all] Error 2 
```