### PR TITLE
Dchoptiany poruszanie refactor

### DIFF
--- a/Map/Source/Game.cpp
+++ b/Map/Source/Game.cpp
@@ -27,9 +27,9 @@ Direction Game::getDirection()
 
 void Game::makeMove(const Direction& direction)
 {
-    bool canMove = _map.isMovePossible(_player.getCurrentPosition(), direction);
+    bool isMovePossible = _map.isMovePossible(_player.getCurrentPosition(), direction);
 
-    if(canMove)
+    if(isMovePossible)
     {
         Position newPosition = _player.getCurrentPosition();
 

--- a/Map/Source/SquareMap.cpp
+++ b/Map/Source/SquareMap.cpp
@@ -152,7 +152,7 @@ bool SquareMap::isMoveLeftPossible(const Position& coordinates)
 
 void SquareMap::makeFieldEmpty(const Position& position)
 {
-    if(position._x < 0 || position._y < 0 || position._x >= getFields().size() || position._y >= getFields().size())
+    if(position._x >= getFields().size() || position._y >= getFields().size())
     {
         throw std::out_of_range("Out of range");
     }


### PR DESCRIPTION
Dwie małe zmiany:
1. Usunąłem warunki sprawdzające, czy x > 0, kiedy x jest typu bez znaku.
2. Zmieniłem nazwę warunku z canMove na isMovePossible zgodnie z wcześniejszą sugestią.